### PR TITLE
Reduce allocations in Resolver.Resolve.

### DIFF
--- a/resolver_test.go
+++ b/resolver_test.go
@@ -37,7 +37,7 @@ func TestCache(t *testing.T) {
 	rrs, err := r.ResolveErr("a.com", "")
 	st.Expect(t, err, NXDOMAIN)
 	st.Expect(t, rrs, (RRs)(nil))
-	st.Expect(t, r.cache.entries["a.com"].rrs, map[RR]struct{}(nil))
+	st.Expect(t, r.cache.entries["a.com"], entry(nil))
 	st.Expect(t, len(rrs), 0)
 	st.Expect(t, len(r.cache.entries), 10)
 }
@@ -47,8 +47,8 @@ func TestGoogleA(t *testing.T) {
 	rrs, err := r.ResolveErr("google.com", "A")
 	st.Expect(t, err, nil)
 	st.Expect(t, len(rrs) >= 4, true)
-	st.Expect(t, count(rrs, func(rr *RR) bool { return rr.Type == "NS" }) >= 2, true)
-	st.Expect(t, count(rrs, func(rr *RR) bool { return rr.Type == "A" }) >= 1, true)
+	st.Expect(t, count(rrs, func(rr RR) bool { return rr.Type == "NS" }) >= 2, true)
+	st.Expect(t, count(rrs, func(rr RR) bool { return rr.Type == "A" }) >= 1, true)
 }
 
 func TestGoogleAny(t *testing.T) {
@@ -56,8 +56,8 @@ func TestGoogleAny(t *testing.T) {
 	rrs, err := r.ResolveErr("google.com", "")
 	st.Expect(t, err, nil)
 	st.Expect(t, len(rrs) >= 1, true)
-	st.Expect(t, count(rrs, func(rr *RR) bool { return rr.Type == "NS" }) >= 2, true)
-	st.Expect(t, count(rrs, func(rr *RR) bool { return rr.Type == "A" }) >= 1, true)
+	st.Expect(t, count(rrs, func(rr RR) bool { return rr.Type == "NS" }) >= 2, true)
+	st.Expect(t, count(rrs, func(rr RR) bool { return rr.Type == "A" }) >= 1, true)
 }
 
 func TestGoogleMulti(t *testing.T) {
@@ -67,8 +67,8 @@ func TestGoogleMulti(t *testing.T) {
 	rrs, err := r.ResolveErr("google.com", "TXT")
 	st.Expect(t, err, nil)
 	st.Expect(t, len(rrs) >= 1, true)
-	st.Expect(t, count(rrs, func(rr *RR) bool { return rr.Type == "TXT" }), 1)
-	st.Expect(t, count(rrs, func(rr *RR) bool { return rr.Type == "A" }), 0)
+	st.Expect(t, count(rrs, func(rr RR) bool { return rr.Type == "TXT" }), 1)
+	st.Expect(t, count(rrs, func(rr RR) bool { return rr.Type == "A" }), 0)
 }
 
 func TestGoogleTXT(t *testing.T) {
@@ -76,21 +76,21 @@ func TestGoogleTXT(t *testing.T) {
 	rrs, err := r.ResolveErr("google.com", "TXT")
 	st.Expect(t, err, nil)
 	st.Expect(t, len(rrs) >= 4, true)
-	st.Expect(t, count(rrs, func(rr *RR) bool { return rr.Type == "TXT" }), 1)
+	st.Expect(t, count(rrs, func(rr RR) bool { return rr.Type == "TXT" }), 1)
 }
 
 func TestHerokuA(t *testing.T) {
 	r := New(0)
 	rrs, err := r.ResolveErr("us-east-1-a.route.herokuapp.com", "A")
 	st.Expect(t, err, nil)
-	st.Expect(t, count(rrs, func(rr *RR) bool { return rr.Type == "A" }) >= 1, true)
+	st.Expect(t, count(rrs, func(rr RR) bool { return rr.Type == "A" }) >= 1, true)
 }
 
 func TestHerokuTXT(t *testing.T) {
 	r := New(0)
 	rrs, err := r.ResolveErr("us-east-1-a.route.herokuapp.com", "TXT")
 	st.Expect(t, err, nil)
-	st.Expect(t, count(rrs, func(rr *RR) bool { return rr.Type == "TXT" }), 0)
+	st.Expect(t, count(rrs, func(rr RR) bool { return rr.Type == "TXT" }), 0)
 }
 
 func TestHerokuMulti(t *testing.T) {
@@ -99,8 +99,8 @@ func TestHerokuMulti(t *testing.T) {
 	st.Expect(t, err, nil)
 	rrs, err := r.ResolveErr("us-east-1-a.route.herokuapp.com", "TXT")
 	st.Expect(t, err, nil)
-	st.Expect(t, count(rrs, func(rr *RR) bool { return rr.Type == "TXT" }), 0)
-	st.Expect(t, count(rrs, func(rr *RR) bool { return rr.Type == "A" }), 0)
+	st.Expect(t, count(rrs, func(rr RR) bool { return rr.Type == "TXT" }), 0)
+	st.Expect(t, count(rrs, func(rr RR) bool { return rr.Type == "A" }), 0)
 }
 
 func TestBlueOvenA(t *testing.T) {
@@ -108,8 +108,8 @@ func TestBlueOvenA(t *testing.T) {
 	rrs, err := r.ResolveErr("blueoven.com", "A")
 	st.Expect(t, err, nil)
 	st.Expect(t, len(rrs), 4)
-	st.Expect(t, count(rrs, func(rr *RR) bool { return rr.Type == "NS" }), 2)
-	st.Expect(t, count(rrs, func(rr *RR) bool { return rr.Type == "A" }), 2)
+	st.Expect(t, count(rrs, func(rr RR) bool { return rr.Type == "NS" }), 2)
+	st.Expect(t, count(rrs, func(rr RR) bool { return rr.Type == "A" }), 2)
 }
 
 func TestBlueOvenAny(t *testing.T) {
@@ -117,8 +117,8 @@ func TestBlueOvenAny(t *testing.T) {
 	rrs, err := r.ResolveErr("blueoven.com", "")
 	st.Expect(t, err, nil)
 	st.Expect(t, len(rrs), 4)
-	st.Expect(t, count(rrs, func(rr *RR) bool { return rr.Type == "NS" }), 2)
-	st.Expect(t, count(rrs, func(rr *RR) bool { return rr.Type == "A" }), 2)
+	st.Expect(t, count(rrs, func(rr RR) bool { return rr.Type == "NS" }), 2)
+	st.Expect(t, count(rrs, func(rr RR) bool { return rr.Type == "A" }), 2)
 }
 
 func TestBlueOvenMulti(t *testing.T) {
@@ -130,7 +130,7 @@ func TestBlueOvenMulti(t *testing.T) {
 	rrs, err := r.ResolveErr("blueoven.com", "")
 	st.Expect(t, err, nil)
 	st.Expect(t, len(rrs), 2)
-	st.Expect(t, all(rrs, func(rr *RR) bool { return rr.Type == "NS" }), true)
+	st.Expect(t, all(rrs, func(rr RR) bool { return rr.Type == "NS" }), true)
 }
 
 func TestBazCoUKAny(t *testing.T) {
@@ -138,7 +138,7 @@ func TestBazCoUKAny(t *testing.T) {
 	rrs, err := r.ResolveErr("baz.co.uk", "")
 	st.Expect(t, err, nil)
 	st.Expect(t, len(rrs) >= 2, true)
-	st.Expect(t, count(rrs, func(rr *RR) bool { return rr.Type == "NS" }) >= 2, true)
+	st.Expect(t, count(rrs, func(rr RR) bool { return rr.Type == "NS" }) >= 2, true)
 }
 
 func BenchmarkResolve(b *testing.B) {
@@ -167,7 +167,7 @@ func testResolveErr() {
 	testResolver.ResolveErr("us-east-1-a.route.herokuapp.com", "")
 }
 
-func count(rrs RRs, f func(*RR) bool) (out int) {
+func count(rrs RRs, f func(RR) bool) (out int) {
 	for _, rr := range rrs {
 		if f(rr) {
 			out++
@@ -176,14 +176,14 @@ func count(rrs RRs, f func(*RR) bool) (out int) {
 	return
 }
 
-func sum(rrs RRs, f func(*RR) int) (out int) {
+func sum(rrs RRs, f func(RR) int) (out int) {
 	for _, rr := range rrs {
 		out += f(rr)
 	}
 	return
 }
 
-func all(rrs RRs, f func(*RR) bool) (out bool) {
+func all(rrs RRs, f func(RR) bool) (out bool) {
 	for _, rr := range rrs {
 		if !f(rr) {
 			return false

--- a/root_cache.go
+++ b/root_cache.go
@@ -18,7 +18,8 @@ func init() {
 		if t.Error != nil {
 			continue
 		}
-		if rr := convertRR(t.RR); rr != nil {
+		rr, ok := convertRR(t.RR)
+		if ok {
 			rootCache.add(rr.Name, rr)
 		}
 	}


### PR DESCRIPTION
Result:
-60% fewer allocs (30 → 12)
+45% more memory (1.3K → 1.8K)
+11% execution time (6.5µs → 7µs)

After:
BenchmarkResolve	  200000	      7218 ns/op	    1840 B/op	      12 allocs/op
BenchmarkResolveErr	  200000	      7151 ns/op	    1840 B/op	      12 allocs/op

Before:
BenchmarkResolve	  200000	      6500 ns/op	    1264 B/op	      30 allocs/op
BenchmarkResolveErr	  200000	      6447 ns/op	    1264 B/op	      30 allocs/op