### PR TITLE
apply a default handling for the conversion

### DIFF
--- a/resolver_test.go
+++ b/resolver_test.go
@@ -77,6 +77,24 @@ func TestGoogleA(t *testing.T) {
 	st.Expect(t, count(rrs, func(rr RR) bool { return rr.Type == "A" }) >= 1, true)
 }
 
+func TestGooglePTR(t *testing.T) {
+	r := New(0)
+	rrs, err := r.ResolveErr("99.17.217.172.in-addr.arpa", "PTR")
+	st.Expect(t, err, nil)
+	st.Expect(t, len(rrs) >= 4, true)
+	st.Expect(t, count(rrs, func(rr RR) bool { return rr.Type == "PTR" }) >= 1, true)
+}
+
+func TestGoogleMX(t *testing.T) {
+	r := New(0)
+	rrs, err := r.ResolveErr("google.com", "MX")
+	t.Errorf("rrs: %+v", rrs)
+	st.Expect(t, err, nil)
+	st.Expect(t, len(rrs) >= 4, true)
+	st.Expect(t, count(rrs, func(rr RR) bool { return rr.Type == "NS" }) >= 2, true)
+	st.Expect(t, count(rrs, func(rr RR) bool { return rr.Type == "MX" }) >= 2, true)
+}
+
 func TestGoogleAny(t *testing.T) {
 	r := New(0)
 	rrs, err := r.ResolveErr("google.com", "")

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -88,7 +88,6 @@ func TestGooglePTR(t *testing.T) {
 func TestGoogleMX(t *testing.T) {
 	r := New(0)
 	rrs, err := r.ResolveErr("google.com", "MX")
-	t.Errorf("rrs: %+v", rrs)
 	st.Expect(t, err, nil)
 	st.Expect(t, len(rrs) >= 4, true)
 	st.Expect(t, count(rrs, func(rr RR) bool { return rr.Type == "NS" }) >= 2, true)

--- a/rr.go
+++ b/rr.go
@@ -50,6 +50,11 @@ func convertRR(drr dns.RR) (RR, bool) {
 		return RR{toLowerFQDN(t.Hdr.Name), "AAAA", t.AAAA.String()}, true
 	case *dns.TXT:
 		return RR{toLowerFQDN(t.Hdr.Name), "TXT", strings.Join(t.Txt, "\t")}, true
+	default:
+		fields := strings.Fields(drr.String())
+		if len(fields) >= 4 {
+			return RR{toLowerFQDN(fields[0]), fields[3], strings.Join(fields[4:len(fields)], "\t")}, true
+		}
 	}
 	return RR{}, false
 }

--- a/rr.go
+++ b/rr.go
@@ -36,7 +36,7 @@ func (rr *RR) String() string {
 // convertRR converts a dns.RR to an RR.
 // If the RR is not a type that this package uses,
 // It will attempt to translate this if there are enough parameters
-// Should all maners of translation fail, it returns an undefined RR and false.
+// Should all translation fail, it returns an undefined RR and false.
 func convertRR(drr dns.RR) (RR, bool) {
 	switch t := drr.(type) {
 	case *dns.SOA:
@@ -54,7 +54,7 @@ func convertRR(drr dns.RR) (RR, bool) {
 	default:
 		fields := strings.Fields(drr.String())
 		if len(fields) >= 4 {
-			return RR{toLowerFQDN(fields[0]), fields[3], strings.Join(fields[4:len(fields)], "\t")}, true
+			return RR{toLowerFQDN(fields[0]), fields[3], strings.Join(fields[4:], "\t")}, true
 		}
 	}
 	return RR{}, false

--- a/rr.go
+++ b/rr.go
@@ -35,7 +35,8 @@ func (rr *RR) String() string {
 
 // convertRR converts a dns.RR to an RR.
 // If the RR is not a type that this package uses,
-// it returns an undefined RR and false.
+// It will attempt to translate this if there are enough parameters
+// Should all maners of translation fail, it returns an undefined RR and false.
 func convertRR(drr dns.RR) (RR, bool) {
 	switch t := drr.(type) {
 	case *dns.SOA:


### PR DESCRIPTION
apply a default handling for the conversion since 90% of all records follow this logic.
This allows most queries to work, even if not specifically defined in the conversion.