### PR TITLE
Correct TTL string

### DIFF
--- a/rr.go
+++ b/rr.go
@@ -38,7 +38,7 @@ func (rr *RR) String() string {
 		return rr.Name + "\t      3600\tIN\t" + rr.Type + "\t" + rr.Value
 	} else {
 		ttl := ttlString(rr.TTL)
-		return rr.Name + "\t" + ttl + "\t" + rr.Type + "\t" + rr.Value
+		return rr.Name + "\t" + ttl + "\tIN\t" + rr.Type + "\t" + rr.Value
 	}
 }
 

--- a/rr_test.go
+++ b/rr_test.go
@@ -2,6 +2,7 @@ package dnsr
 
 import (
 	"testing"
+	"time"
 
 	"github.com/nbio/st"
 )
@@ -14,4 +15,17 @@ func TestRRStringStandard(t *testing.T) {
 	}
 	result := rr.String()
 	st.Expect(t, result, "example.com.	      3600	IN	A	203.0.113.1")
+}
+
+func TestRRStringExpiring(t *testing.T) {
+	ttl := 86400 * time.Second
+	rr := RR{
+		Name:   "example.com.",
+		Type:   "A",
+		Value:  "203.0.113.1",
+		TTL:    ttl,
+		Expiry: time.Now().Add(ttl),
+	}
+	result := rr.String()
+	st.Expect(t, result, "example.com.	     86400	IN	A	203.0.113.1")
 }

--- a/rr_test.go
+++ b/rr_test.go
@@ -1,0 +1,17 @@
+package dnsr
+
+import (
+	"testing"
+
+	"github.com/nbio/st"
+)
+
+func TestRRStringStandard(t *testing.T) {
+	rr := RR{
+		Name:  "example.com.",
+		Type:  "A",
+		Value: "203.0.113.1",
+	}
+	result := rr.String()
+	st.Expect(t, result, "example.com.	      3600	IN	A	203.0.113.1")
+}


### PR DESCRIPTION
Corrects string representation of a resource record with TTL.

Left out the class field in the TTL patch. Adds the class.