### PR TITLE
Fetch root zone using a secure connection

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 echo "package dnsr\n\nvar root = \`" > root.go
-curl http://www.internic.net/domain/named.root >> root.go
+curl https://www.internic.net/domain/named.root >> root.go
 echo "\`" >> root.go


### PR DESCRIPTION
HTTP is insecure and important data like a root zone should be fetched using a secure connection.