### PR TITLE
Overcompensate for hijacked DNS

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -3,7 +3,7 @@ name: Go
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 jobs:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -26,8 +26,6 @@ jobs:
         run: go vet ./...
 
       - name: Test Go code
-        env:
-          DNSR_DEBUG: 1
         run: go test -v -race ./...
 
       - name: Verify repo is unchanged

--- a/.github/workflows/network.yaml
+++ b/.github/workflows/network.yaml
@@ -3,7 +3,7 @@ name: Network
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 jobs:

--- a/logging.go
+++ b/logging.go
@@ -107,3 +107,12 @@ func logCancellation(host string, qmsg *dns.Msg, rmsg *dns.Msg, depth int, dur t
 	}
 	fmt.Fprintf(DebugLogger, "== CANCELED ==\n")
 }
+
+func logMsg(msg *dns.Msg) {
+	if DebugLogger == nil {
+		return
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	fmt.Fprintln(DebugLogger, msg.String())
+}

--- a/resolver.go
+++ b/resolver.go
@@ -302,15 +302,17 @@ func (r *Resolver) exchangeIP(ctx context.Context, host, ip, qname, qtype string
 				continue
 			}
 			arrs, err := r.cacheGet(ctx, rr.Value, "A")
-			if err != nil {
+			if err == NXDOMAIN {
 				continue
 			}
+			if err != nil {
+				break
+			}
 			if len(arrs) == 0 {
-				arrs, err = r.exchangeIP(ctx, host, ip, rr.Value, "A", depth)
+				arrs, err = r.exchangeIP(ctx, host, ip, rr.Value, "A", depth+1)
 				if err != nil {
-					continue
+					break
 				}
-				// fmt.Printf("dig @%s %s A\n\t%#v\n", host, rr.Value, arrs)
 			}
 			rrs = append(rrs, arrs...)
 		}

--- a/resolver.go
+++ b/resolver.go
@@ -208,22 +208,14 @@ func (r *Resolver) iterateParents(ctx context.Context, qname, qtype string, dept
 }
 
 func (r *Resolver) exchange(ctx context.Context, host, qname, qtype string, depth int) (RRs, error) {
-	dtype := dns.StringToType[qtype]
-	if dtype == 0 {
-		dtype = dns.TypeA
-	}
-	qmsg := &dns.Msg{}
-	qmsg.SetQuestion(qname, dtype)
-	qmsg.MsgHdr.RecursionDesired = false
-
-	// Find each A record for the DNS server
 	count := 0
 	arrs, err := r.resolve(ctx, host, "A", depth)
 	if err != nil {
 		return nil, err
 	}
 	for _, arr := range arrs {
-		if arr.Type != "A" { // FIXME: support AAAA records?
+		// FIXME: support AAAA records?
+		if arr.Type != "A" {
 			continue
 		}
 
@@ -232,60 +224,74 @@ func (r *Resolver) exchange(ctx context.Context, host, qname, qtype string, dept
 			return nil, ErrMaxIPs
 		}
 
-		// Synchronously query this DNS server
-		start := time.Now()
-		timeout := r.timeout // belt and suspenders, since ctx has a deadline from ResolveErr
-		if dl, ok := ctx.Deadline(); ok {
-			if start.After(dl.Add(-TypicalResponseTime)) { // bail if we can't finish in time (start is too close to deadline)
-				return nil, ErrTimeout
-			}
-			timeout = dl.Sub(start)
+		rrs, err := r.exchangeIP(ctx, host, arr.Value, qname, qtype, depth)
+		if err == nil || err == NXDOMAIN {
+			return rrs, err
 		}
-
-		client := &dns.Client{Timeout: timeout} // client must finish within remaining timeout
-		rmsg, dur, err := client.Exchange(qmsg, arr.Value+":53")
-		select {
-		case <-ctx.Done(): // Finished too late
-			logCancellation(host, qmsg, rmsg, depth, dur, timeout)
-			return nil, ctx.Err()
-		default:
-			logExchange(host, qmsg, rmsg, depth, dur, timeout, err) // Log hostname instead of IP
-		}
-		if err != nil {
-			continue
-		}
-
-		// FIXME: cache NXDOMAIN responses responsibly
-		if rmsg.Rcode == dns.RcodeNameError {
-			var hasSOA bool
-			if qtype == "NS" {
-				for _, drr := range rmsg.Ns {
-					rr, ok := convertRR(drr, r.expire)
-					if !ok {
-						continue
-					}
-					if rr.Type == "SOA" {
-						hasSOA = true
-						break
-					}
-				}
-			}
-			if !hasSOA {
-				r.cache.addNX(qname)
-				return nil, NXDOMAIN
-			}
-		} else if rmsg.Rcode != dns.RcodeSuccess {
-			return nil, errors.New(dns.RcodeToString[rmsg.Rcode])
-		}
-
-		// Cache records returned
-		rrs := r.saveDNSRR(host, qname, append(append(rmsg.Answer, rmsg.Ns...), rmsg.Extra...))
-
-		// Return after first successful network request
-		return rrs, nil
 	}
 
 	return nil, ErrNoARecords
+}
+
+func (r *Resolver) exchangeIP(ctx context.Context, host, ip, qname, qtype string, depth int) (RRs, error) {
+	dtype := dns.StringToType[qtype]
+	if dtype == 0 {
+		dtype = dns.TypeA
+	}
+	var qmsg dns.Msg
+	qmsg.SetQuestion(qname, dtype)
+	qmsg.MsgHdr.RecursionDesired = false
+
+	// Synchronously query this DNS server
+	start := time.Now()
+	timeout := r.timeout // belt and suspenders, since ctx has a deadline from ResolveErr
+	if dl, ok := ctx.Deadline(); ok {
+		if start.After(dl.Add(-TypicalResponseTime)) { // bail if we can't finish in time (start is too close to deadline)
+			return nil, ErrTimeout
+		}
+		timeout = dl.Sub(start)
+	}
+
+	client := &dns.Client{Timeout: timeout} // client must finish within remaining timeout
+	rmsg, dur, err := client.Exchange(&qmsg, ip+":53")
+	select {
+	case <-ctx.Done(): // Finished too late
+		logCancellation(host, &qmsg, rmsg, depth, dur, timeout)
+		return nil, ctx.Err()
+	default:
+		logExchange(host, &qmsg, rmsg, depth, dur, timeout, err) // Log hostname instead of IP
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// FIXME: cache NXDOMAIN responses responsibly
+	if rmsg.Rcode == dns.RcodeNameError {
+		var hasSOA bool
+		if qtype == "NS" {
+			for _, drr := range rmsg.Ns {
+				rr, ok := convertRR(drr, r.expire)
+				if !ok {
+					continue
+				}
+				if rr.Type == "SOA" {
+					hasSOA = true
+					break
+				}
+			}
+		}
+		if !hasSOA {
+			r.cache.addNX(qname)
+			return nil, NXDOMAIN
+		}
+	} else if rmsg.Rcode != dns.RcodeSuccess {
+		return nil, errors.New(dns.RcodeToString[rmsg.Rcode])
+	}
+
+	// Cache records returned
+	rrs := r.saveDNSRR(host, qname, append(append(rmsg.Answer, rmsg.Ns...), rmsg.Extra...))
+
+	return rrs, nil
 }
 
 func (r *Resolver) resolveCNAMEs(ctx context.Context, qname, qtype string, crrs RRs, depth int) (RRs, error) {

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -15,7 +15,7 @@ import (
 func TestMain(m *testing.M) {
 	flag.Parse()
 	if israce.Enabled {
-		Timeout *= 2
+		Timeout *= 3
 	}
 	if os.Getenv("DNSR_DEBUG") != "" {
 		DebugLogger = os.Stderr


### PR DESCRIPTION
This should produce more reliable queries in the presence of DNS hijacking at the expense of more time + network requests.