### PR TITLE
Add net.Dialer override, configurable through options

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -39,12 +39,12 @@ type Resolver struct {
 }
 
 // ResolverOption configures a single resolver setting
-type ResolverOption func(r *Resolver)
+type resolverOption func(r *Resolver)
 
 // NewResolver creates a resolver with the given cache capacity and a set of extra options.
-func NewResolver(capacity int, options ...ResolverOption) *Resolver {
+func NewResolver(options ...resolverOption) *Resolver {
 	r := &Resolver{
-		cache:   newCache(capacity, false),
+		cache:   newCache(0, false),
 		expire:  false,
 		timeout: Timeout,
 	}
@@ -54,15 +54,15 @@ func NewResolver(capacity int, options ...ResolverOption) *Resolver {
 	return r
 }
 
-// WithTimeout returns a ResolverOption that can be used on NewResolver to change the timeout of the name resolution.
-func WithTimeout(timeout time.Duration) ResolverOption {
+// WithTimeout returns a resolverOption that can be used on NewResolver to change the timeout of the name resolution.
+func WithTimeout(timeout time.Duration) resolverOption {
 	return func(r *Resolver) {
 		r.timeout = timeout
 	}
 }
 
-// Expiring returns a ResolverOption that can be used on NewResolver to change the resolver cache to be expiring.
-func Exipiring() ResolverOption {
+// Expiring returns a resolverOption that can be used on NewResolver to change the resolver cache to be expiring.
+func Expiring() resolverOption {
 	return func(r *Resolver) {
 		capacity := r.cache.capacity
 		r.cache = newCache(capacity, true)
@@ -70,9 +70,16 @@ func Exipiring() ResolverOption {
 	}
 }
 
-// WithDialer returns a ResolverOption that can be used on NewResolver to change the resolver dialer.
+// WithCapacity returns a resolverOption that can be used on NewResolver to change the cache capacity of the resolver.
+func WithCapacity(capacity int) resolverOption {
+	return func(r *Resolver) {
+		r.cache = newCache(capacity, r.expire)
+	}
+}
+
+// WithDialer returns a resolverOption that can be used on NewResolver to change the resolver dialer.
 // A custom dialer can be used to specify the local ip address.
-func WithDialer(dialer *net.Dialer) ResolverOption {
+func WithDialer(dialer *net.Dialer) resolverOption {
 	return func(r *Resolver) {
 		r.dialer = dialer
 	}

--- a/resolver.go
+++ b/resolver.go
@@ -44,21 +44,6 @@ type ResolverOption resolverOption
 // resolverOption is the private resolver option type
 type resolverOption func(r *Resolver) error
 
-// NewResolver creates a resolver with the given cache capacity and a set of extra options.
-func NewResolver(options ...ResolverOption) (*Resolver, error) {
-	r := &Resolver{
-		cache:   newCache(0, false),
-		expire:  false,
-		timeout: Timeout,
-	}
-	for _, option := range options {
-		if err := option(r); err != nil {
-			return nil, err
-		}
-	}
-	return r, nil
-}
-
 // WithTimeout returns a resolverOption that can be used on NewResolver to change the timeout of the name resolution.
 func WithTimeout(timeout time.Duration) ResolverOption {
 	return func(r *Resolver) error {
@@ -94,33 +79,50 @@ func WithDialer(dialer *net.Dialer) ResolverOption {
 	}
 }
 
+// NewResolver creates a resolver with the given cache capacity and a set of extra options.
+func NewResolver(options ...ResolverOption) (*Resolver, error) {
+	r := &Resolver{
+		cache:   newCache(0, false),
+		expire:  false,
+		timeout: Timeout,
+	}
+	for _, option := range options {
+		if err := option(r); err != nil {
+			return nil, err
+		}
+	}
+	return r, nil
+}
+
 // New initializes a Resolver with the specified cache size.
+//
+// Deprecated: Use NewResolver instead.
 func New(capacity int) *Resolver {
-	return NewWithTimeout(capacity, Timeout)
+	r, _ := NewResolver(WithCapacity(capacity))
+	return r
 }
 
 // NewWithTimeout initializes a Resolver with the specified cache size and resolution timeout.
+//
+// Deprecated: Use NewResolver instead.
 func NewWithTimeout(capacity int, timeout time.Duration) *Resolver {
-	r := &Resolver{
-		cache:   newCache(capacity, false),
-		expire:  false,
-		timeout: timeout,
-	}
+	r, _ := NewResolver(WithCapacity(capacity), WithTimeout(timeout))
 	return r
 }
 
 // NewExpiring initializes an expiring Resolver with the specified cache size.
+//
+// Deprecated: Use NewResolver instead.
 func NewExpiring(capacity int) *Resolver {
-	return NewExpiringWithTimeout(capacity, Timeout)
+	r, _ := NewResolver(Expiring(), WithCapacity(capacity))
+	return r
 }
 
 // NewExpiringWithTimeout initializes an expiring Resolved with the specified cache size and resolution timeout.
+//
+// Deprecated: Use NewResolver instead.
 func NewExpiringWithTimeout(capacity int, timeout time.Duration) *Resolver {
-	r := &Resolver{
-		cache:   newCache(capacity, true),
-		expire:  true,
-		timeout: timeout,
-	}
+	r, _ := NewResolver(Expiring(), WithCapacity(capacity), WithTimeout(timeout))
 	return r
 }
 

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -29,8 +29,20 @@ func TestSimple(t *testing.T) {
 	st.Expect(t, err, NXDOMAIN)
 }
 
+func TestSimpleFuncOptions(t *testing.T) {
+	r := NewResolver(WithCapacity(0))
+	_, err := r.ResolveErr("1.com", "")
+	st.Expect(t, err, NXDOMAIN)
+}
+
 func TestTimeoutExpiration(t *testing.T) {
 	r := NewWithTimeout(0, 10*time.Millisecond)
+	_, err := r.ResolveErr("1.com", "")
+	st.Expect(t, err, ErrTimeout)
+}
+
+func TestTimeoutExpirationFuncOptions(t *testing.T) {
+	r := NewResolver(WithTimeout(10 * time.Millisecond))
 	_, err := r.ResolveErr("1.com", "")
 	st.Expect(t, err, ErrTimeout)
 }
@@ -41,8 +53,8 @@ func TestDeadlineExceeded(t *testing.T) {
 	st.Expect(t, err, context.DeadlineExceeded)
 }
 
-func TestFluentConstructorDeadlineExceeded(t *testing.T) {
-	r := NewResolver(0, WithTimeout(0))
+func TestDeadlineExceededFuncOptions(t *testing.T) {
+	r := NewResolver(WithTimeout(0))
 	_, err := r.ResolveErr("1.com", "")
 	st.Expect(t, err, context.DeadlineExceeded)
 }
@@ -201,6 +213,15 @@ func TestBazCoUKAny(t *testing.T) {
 
 func TestTTL(t *testing.T) {
 	r := NewExpiring(0)
+	rrs, err := r.ResolveErr("google.com", "A")
+	st.Expect(t, err, nil)
+	st.Assert(t, len(rrs) >= 4, true)
+	rr := rrs[0]
+	st.Expect(t, !rr.Expiry.IsZero(), true)
+}
+
+func TestTTLFuncOptions(t *testing.T) {
+	r := NewResolver(Expiring())
 	rrs, err := r.ResolveErr("google.com", "A")
 	st.Expect(t, err, nil)
 	st.Assert(t, len(rrs) >= 4, true)

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -41,6 +41,12 @@ func TestDeadlineExceeded(t *testing.T) {
 	st.Expect(t, err, context.DeadlineExceeded)
 }
 
+func TestFluentConstructorDeadlineExceeded(t *testing.T) {
+	r := NewResolver(0, WithTimeout(0))
+	_, err := r.ResolveErr("1.com", "")
+	st.Expect(t, err, context.DeadlineExceeded)
+}
+
 func TestResolveCtx(t *testing.T) {
 	r := New(0)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -31,7 +31,7 @@ func TestSimple(t *testing.T) {
 }
 
 func TestSimpleFuncOptions(t *testing.T) {
-	r := NewResolver(WithCapacity(0))
+	r, _ := NewResolver(WithCapacity(0))
 	_, err := r.ResolveErr("1.com", "")
 	st.Expect(t, err, NXDOMAIN)
 }
@@ -43,7 +43,7 @@ func TestTimeoutExpiration(t *testing.T) {
 }
 
 func TestTimeoutExpirationFuncOptions(t *testing.T) {
-	r := NewResolver(WithTimeout(10 * time.Millisecond))
+	r, _ := NewResolver(WithTimeout(10 * time.Millisecond))
 	_, err := r.ResolveErr("1.com", "")
 	st.Expect(t, err, ErrTimeout)
 }
@@ -55,13 +55,13 @@ func TestDeadlineExceeded(t *testing.T) {
 }
 
 func TestDeadlineExceededFuncOptions(t *testing.T) {
-	r := NewResolver(WithTimeout(0))
+	r, _ := NewResolver(WithTimeout(0))
 	_, err := r.ResolveErr("1.com", "")
 	st.Expect(t, err, context.DeadlineExceeded)
 }
 
 func TestDialer(t *testing.T) {
-	r := NewResolver(WithDialer(&net.Dialer{
+	r, _ := NewResolver(WithDialer(&net.Dialer{
 		// iterative resolving from 127.0.0.1 should never work
 		LocalAddr: &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 65353},
 	}))
@@ -234,7 +234,7 @@ func TestTTL(t *testing.T) {
 }
 
 func TestTTLFuncOptions(t *testing.T) {
-	r := NewResolver(Expiring())
+	r, _ := NewResolver(Expiring())
 	rrs, err := r.ResolveErr("google.com", "A")
 	st.Expect(t, err, nil)
 	st.Assert(t, len(rrs) >= 4, true)


### PR DESCRIPTION
This should fix #40 

The `dns.Client` exposes `Dialer: net.Dialer` which can be used to specify the local IP address (and various other options).

The `NewXXX` methods started to become larger and larger, so I've added an Options based configuration / constructor - a common way to expose more options to clients without opening the datastructure.

Feel free to mangle this in any way you like. I saw #40 and thought I could need something like this and hacked it up.