### PR TITLE
Fixed so canceled ctx is not propegated into resolveCNAME

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -180,7 +180,7 @@ func (r *Resolver) resolve(ctx context.Context, qname, qtype string, depth int) 
 func (r *Resolver) iterateParents(ctx context.Context, qname, qtype string, depth int) (RRs, error) {
 	chanRRs := make(chan RRs, MaxNameservers)
 	chanErrs := make(chan error, MaxNameservers)
-	ctx, cancel := context.WithCancel(ctx)
+	child_ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	for pname, ok := qname, true; ok; pname, ok = parent(pname) {
 		// If we’re looking for [foo.com,NS], then move on to the parent ([com,NS])
@@ -195,7 +195,7 @@ func (r *Resolver) iterateParents(ctx context.Context, qname, qtype string, dept
 		}
 
 		// Get nameservers
-		nrrs, err := r.resolve(ctx, pname, "NS", depth)
+		nrrs, err := r.resolve(child_ctx, pname, "NS", depth)
 		if err == NXDOMAIN || err == ErrTimeout || err == context.DeadlineExceeded {
 			return nil, err
 		}
@@ -205,7 +205,7 @@ func (r *Resolver) iterateParents(ctx context.Context, qname, qtype string, dept
 
 		// Check cache for specific queries
 		if len(nrrs) > 0 && qtype != "" {
-			rrs, err := r.cacheGet(ctx, qname, qtype)
+			rrs, err := r.cacheGet(child_ctx, qname, qtype)
 			if err != nil {
 				return nil, err
 			}
@@ -223,7 +223,7 @@ func (r *Resolver) iterateParents(ctx context.Context, qname, qtype string, dept
 			}
 
 			go func(host string) {
-				rrs, err := r.exchange(ctx, host, qname, qtype, depth)
+				rrs, err := r.exchange(child_ctx, host, qname, qtype, depth)
 				if err != nil {
 					chanErrs <- err
 				} else {
@@ -237,8 +237,8 @@ func (r *Resolver) iterateParents(ctx context.Context, qname, qtype string, dept
 		// Wait for answer, error, or cancellation
 		for ; count > 0; count-- {
 			select {
-			case <-ctx.Done():
-				return nil, ctx.Err()
+			case <-child_ctx.Done():
+				return nil, child_ctx.Err()
 			case rrs := <-chanRRs:
 				for _, nrr := range nrrs {
 					if nrr.Name == qname {

--- a/resolver.go
+++ b/resolver.go
@@ -407,7 +407,7 @@ func (r *Resolver) resolveCNAMEs(ctx context.Context, qname, qtype string, crrs 
 		crrs, _ := r.resolve(ctx, crr.Value, qtype, depth)
 		for _, rr := range crrs {
 			r.cache.add(qname, rr)
-			rrs = append(rrs, crr)
+			rrs = append(rrs, rr)
 		}
 	}
 	return rrs, nil

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -252,6 +252,21 @@ func TestTTL(t *testing.T) {
 	st.Expect(t, rr.Expiry.IsZero(), false)
 }
 
+func TestCNAMETXT(t *testing.T) {
+	r := NewExpiring(0)
+	rrs, err := r.ResolveErr("355702a0-beac-4944-ae69-73c70d68b5c3.miniwoffer.no", "TXT")
+	st.Expect(t, err, nil)
+	st.Assert(t, len(rrs) >= 1, true)
+	txt_record := false
+	for _, v := range rrs {
+		if v.Type == "TXT" {
+			st.Expect(t, v.Value, "foobar")
+			txt_record = true
+		}
+	}
+	st.Expect(t, txt_record, true)
+}
+
 var testResolver *Resolver
 
 func BenchmarkResolve(b *testing.B) {


### PR DESCRIPTION
The `ctx` getting passed into `resolveCNAME` in the `resolve` function is canceled on the line above the call.
My guess is the original `ctx` was supposed to be passed to `resolveCNAME`.