### PR TITLE
Add WithTCPRetry Option to NewResolver

### DIFF
--- a/cmd/dnsr/main.go
+++ b/cmd/dnsr/main.go
@@ -14,16 +14,13 @@ import (
 
 var (
 	verbose  bool
-	resolver = dnsr.New(10000)
+	tcpRetry bool
+	resolver = dnsr.NewResolver(dnsr.WithCache(1000))
 )
 
 func init() {
-	flag.BoolVar(
-		&verbose,
-		"v",
-		false,
-		"print verbose info to the console",
-	)
+	flag.BoolVar(&verbose, "v", false, "print verbose info to the console")
+	flag.BoolVar(&tcpRetry, "t", false, "enable TCP retry")
 }
 
 func logV(fmt string, args ...interface{}) {
@@ -46,6 +43,9 @@ func main() {
 		flag.Usage()
 	} else if _, isType := dns.StringToType[args[len(args)-1]]; len(args) > 1 && isType {
 		qtype, args = args[len(args)-1], args[:len(args)-1]
+	}
+	if tcpRetry {
+		resolver = dnsr.NewResolver(dnsr.WithTCPRetry())
 	}
 	if verbose {
 		dnsr.DebugLogger = os.Stderr

--- a/resolver.go
+++ b/resolver.go
@@ -348,7 +348,7 @@ func (r *Resolver) exchangeIP(ctx context.Context, host, ip, qname, qtype string
 			if start.After(dl.Add(-TypicalResponseTime)) { // bail if we can't finish in time (start is too close to deadline)
 				return nil, ErrTimeout
 			}
-			timeout = dl.Sub(start)
+			client.Timeout = dl.Sub(start)
 		}
 		// Retry with TCP
 		conn, err := dialer.DialContext(ctx, "tcp", addr)
@@ -361,10 +361,10 @@ func (r *Resolver) exchangeIP(ctx context.Context, host, ip, qname, qtype string
 
 	select {
 	case <-ctx.Done(): // Finished too late
-		logCancellation(host, &qmsg, rmsg, depth, dur, timeout)
+		logCancellation(host, &qmsg, rmsg, depth, dur, client.Timeout)
 		return nil, ctx.Err()
 	default:
-		logExchange(host, &qmsg, rmsg, depth, dur, timeout, err) // Log hostname instead of IP
+		logExchange(host, &qmsg, rmsg, depth, dur, client.Timeout, err) // Log hostname instead of IP
 	}
 	if err != nil {
 		return nil, err

--- a/resolver.go
+++ b/resolver.go
@@ -75,7 +75,6 @@ func WithTCPRetry() Option {
 	}
 }
 
-
 // Resolver implements a primitive, non-recursive, caching DNS resolver.
 type Resolver struct {
 	dialer   ContextDialer

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -12,6 +12,30 @@ import (
 	"github.com/nbio/st"
 )
 
+func CheckTXT(t *testing.T, domain string) {
+	r := NewResolver()
+	rrs, err := r.ResolveErr(domain, "TXT")
+	st.Expect(t, err, nil)
+
+	rrs2, err := net.LookupTXT(domain)
+	st.Expect(t, err, nil)
+	for _, rr := range rrs2 {
+		exists := false
+		for _, rr2 := range rrs {
+			if rr2.Type == "TXT" && rr == rr2.Value {
+				exists = true
+			}
+		}
+		if !exists {
+			t.Errorf("TXT record %q not found", rr)
+		}
+	}
+	c := count(rrs, func(rr RR) bool { return rr.Type == "TXT" })
+	if c != len(rrs2) {
+		t.Errorf("TXT record count mismatch: %d != %d", c, len(rrs2))
+	}
+}
+
 func TestMain(m *testing.M) {
 	flag.Parse()
 	timeout := os.Getenv("DNSR_TIMEOUT")
@@ -171,12 +195,11 @@ func TestGoogleMulti(t *testing.T) {
 }
 
 func TestGoogleTXT(t *testing.T) {
-	r := NewResolver()
-	rrs, err := r.ResolveErr("google.com", "TXT")
-	st.Expect(t, err, nil)
-	st.Expect(t, len(rrs) >= 4, true)
-	// Google will have at least an SPF record, but might transiently have verification records too.
-	st.Expect(t, count(rrs, func(rr RR) bool { return rr.Type == "TXT" }) >= 1, true)
+	CheckTXT(t, "google.com")
+}
+
+func TestCloudflareTXT(t *testing.T) {
+	CheckTXT(t, "cloudflare.com")
 }
 
 func TestGoogleTXTTCPRetry(t *testing.T) {

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func CheckTXT(t *testing.T, domain string) {
-	r := NewResolver()
+	r := NewResolver(WithTCPRetry())
 	rrs, err := r.ResolveErr(domain, "TXT")
 	st.Expect(t, err, nil)
 
@@ -213,7 +213,6 @@ func TestGoogleTXTTCPRetry(t *testing.T) {
 	st.Expect(t, err, nil)
 	st.Expect(t, len(rrs2) > len(rrs), true)
 }
-
 
 func TestAppleA(t *testing.T) {
 	r := NewResolver()

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -179,6 +179,19 @@ func TestGoogleTXT(t *testing.T) {
 	st.Expect(t, count(rrs, func(rr RR) bool { return rr.Type == "TXT" }) >= 1, true)
 }
 
+func TestGoogleTXTTCPRetry(t *testing.T) {
+	r := NewResolver()
+	rrs, err := r.ResolveErr("google.com", "TXT")
+	st.Expect(t, err, nil)
+	st.Expect(t, len(rrs) >= 4, true)
+
+	r2 := NewResolver(WithTCPRetry())
+	rrs2, err := r2.ResolveErr("google.com", "TXT")
+	st.Expect(t, err, nil)
+	st.Expect(t, len(rrs2) > len(rrs), true)
+}
+
+
 func TestAppleA(t *testing.T) {
 	r := NewResolver()
 	rrs, err := r.ResolveErr("apple.com", "A")


### PR DESCRIPTION
Combines #112 and #118, adding the ability for a resolver to retry a DNS
request that received a truncated response using TCP.

Both requests must complete within the original timeout or deadline.

Thanks @Miniwoffer

- Added WithTCPRetry option that fixses truncated answers
- Update resolver.go
- Fixed so timeout is used correctly on tcp retry
- cmd/dnsr: add -t to expose WithTCPRetry option
- Wrote test to check TXT results with default golang LookupTXT
- Update resolver_test.go
- Update resolver_test.go
- Fixed truncated answer
- fix(resolver_test): use new WithTCPRetry option
