### PR TITLE
resolver: fix CNAME -> TXT recursion

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -254,6 +254,7 @@ func (r *Resolver) iterateParents(ctx context.Context, qname, qtype string, dept
 						rrs = append(rrs, nrr)
 					}
 				}
+				ctx := context.WithoutCancel(ctx)
 				cancel() // stop any other work here before recursing
 				return r.resolveCNAMEs(ctx, qname, qtype, rrs, depth)
 			case err = <-chanErrs:
@@ -432,7 +433,7 @@ func (r *Resolver) resolveCNAMEs(ctx context.Context, qname, qtype string, crrs 
 		crrs, _ := r.resolve(ctx, crr.Value, qtype, depth)
 		for _, rr := range crrs {
 			r.cache.add(qname, rr)
-			rrs = append(rrs, crr)
+			rrs = append(rrs, rr)
 		}
 	}
 	return rrs, nil

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -175,8 +175,8 @@ func TestGoogleCNAME(t *testing.T) {
 	rrs, err := r.ResolveErr("translate.google.com", "A")
 	st.Expect(t, err, nil)
 	st.Expect(t, len(rrs) >= 1, true)
-	st.Expect(t, count(rrs, func(rr RR) bool { return rr.Type == "A" }), 0)
-	st.Expect(t, count(rrs, func(rr RR) bool { return rr.Type == "CNAME" }), 1)
+	st.Expect(t, count(rrs, func(rr RR) bool { return rr.Type == "CNAME" }), 1)     // resolved first
+	st.Expect(t, count(rrs, func(rr RR) bool { return rr.Type == "A" }) >= 1, true) // records for CNAME target
 }
 
 func TestGoogleTXT(t *testing.T) {

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -12,30 +12,6 @@ import (
 	"github.com/nbio/st"
 )
 
-func CheckTXT(t *testing.T, domain string) {
-	r := NewResolver(WithTCPRetry())
-	rrs, err := r.ResolveErr(domain, "TXT")
-	st.Expect(t, err, nil)
-
-	rrs2, err := net.LookupTXT(domain)
-	st.Expect(t, err, nil)
-	for _, rr := range rrs2 {
-		exists := false
-		for _, rr2 := range rrs {
-			if rr2.Type == "TXT" && rr == rr2.Value {
-				exists = true
-			}
-		}
-		if !exists {
-			t.Errorf("TXT record %q not found", rr)
-		}
-	}
-	c := count(rrs, func(rr RR) bool { return rr.Type == "TXT" })
-	if c != len(rrs2) {
-		t.Errorf("TXT record count mismatch: %d != %d", c, len(rrs2))
-	}
-}
-
 func TestMain(m *testing.M) {
 	flag.Parse()
 	timeout := os.Getenv("DNSR_TIMEOUT")
@@ -194,12 +170,21 @@ func TestGoogleMulti(t *testing.T) {
 	st.Expect(t, count(rrs, func(rr RR) bool { return rr.Type == "A" }), 0)
 }
 
+func TestGoogleCNAME(t *testing.T) {
+	r := NewResolver()
+	rrs, err := r.ResolveErr("translate.google.com", "A")
+	st.Expect(t, err, nil)
+	st.Expect(t, len(rrs) >= 1, true)
+	st.Expect(t, count(rrs, func(rr RR) bool { return rr.Type == "A" }), 0)
+	st.Expect(t, count(rrs, func(rr RR) bool { return rr.Type == "CNAME" }), 1)
+}
+
 func TestGoogleTXT(t *testing.T) {
-	CheckTXT(t, "google.com")
+	checkTXT(t, "google.com")
 }
 
 func TestCloudflareTXT(t *testing.T) {
-	CheckTXT(t, "cloudflare.com")
+	checkTXT(t, "cloudflare.com")
 }
 
 func TestGoogleTXTTCPRetry(t *testing.T) {
@@ -285,6 +270,30 @@ func TestTTL(t *testing.T) {
 	st.Assert(t, len(rrs) >= 4, true)
 	rr := rrs[0]
 	st.Expect(t, rr.Expiry.IsZero(), false)
+}
+
+func checkTXT(t *testing.T, domain string) {
+	r := NewResolver(WithTCPRetry())
+	rrs, err := r.ResolveErr(domain, "TXT")
+	st.Expect(t, err, nil)
+
+	rrs2, err := net.LookupTXT(domain)
+	st.Expect(t, err, nil)
+	for _, rr := range rrs2 {
+		exists := false
+		for _, rr2 := range rrs {
+			if rr2.Type == "TXT" && rr == rr2.Value {
+				exists = true
+			}
+		}
+		if !exists {
+			t.Errorf("TXT record %q not found", rr)
+		}
+	}
+	c := count(rrs, func(rr RR) bool { return rr.Type == "TXT" })
+	if c != len(rrs2) {
+		t.Errorf("TXT record count mismatch: %d != %d", c, len(rrs2))
+	}
 }
 
 var testResolver *Resolver


### PR DESCRIPTION
Fixes #115, #123

* Pass non-canceled context to recursive resolveCNAMEs
* Append correct RR in resolveCNAMEs
* Keep TestMain at top of resolver_test.go
* Add TestGoogleCNAME
* Rename CheckTXT -> checkTXT


<details><summary>Output Changes:</summary>
<div>

<p>
Before:

``` console
$ go run ./cmd/dnsr/main.go 355702a0-beac-4944-ae69-73c70d68b5c3.miniwoffer.no TXT

;; RESULTS:
355702a0-beac-4944-ae69-73c70d68b5c3.miniwoffer.no.	      3600	IN	CNAME	355702a0-beac-4944-ae69-73c70d68b5c3.miniwoffer.no.wordcore.no.
;; TRUE	355702a0-beac-4944-ae69-73c70d68b5c3.miniwoffer.no	TXT
;; Elapsed: 1.4088205s

$ go run ./cmd/dnsr/main.go translate.google.com A

;; RESULTS:
translate.google.com.	      3600	IN	CNAME	www3.l.google.com.
;; TRUE	translate.google.com	A
;; Elapsed: 86.525208ms
```
</p>

<p>
After:

``` console
$ go run ./cmd/dnsr/main.go 355702a0-beac-4944-ae69-73c70d68b5c3.miniwoffer.no TXT

;; RESULTS:
355702a0-beac-4944-ae69-73c70d68b5c3.miniwoffer.no.	      3600	IN	CNAME	355702a0-beac-4944-ae69-73c70d68b5c3.miniwoffer.no.wordcore.no.
355702a0-beac-4944-ae69-73c70d68b5c3.miniwoffer.no.wordcore.no.	      3600	IN	TXT	foobar
;; TRUE	355702a0-beac-4944-ae69-73c70d68b5c3.miniwoffer.no	TXT
;; Elapsed: 1.582778084s

❯ dig +short 355702a0-beac-4944-ae69-73c70d68b5c3.miniwoffer.no TXT
355702a0-beac-4944-ae69-73c70d68b5c3.miniwoffer.no.wordcore.no.
"foobar"

$ go run ./cmd/dnsr/main.go translate.google.com A

;; RESULTS:
translate.google.com.	      3600	IN	CNAME	www3.l.google.com.
www3.l.google.com.	      3600	IN	A	142.250.114.101
www3.l.google.com.	      3600	IN	A	142.250.114.100
www3.l.google.com.	      3600	IN	A	142.250.114.102
www3.l.google.com.	      3600	IN	A	142.250.114.138
www3.l.google.com.	      3600	IN	A	142.250.114.139
www3.l.google.com.	      3600	IN	A	142.250.114.113
;; TRUE	translate.google.com	A
;; Elapsed: 144.930083ms

$ dig +short translate.google.com
www3.l.google.com.
142.250.113.139
142.250.113.113
142.250.113.102
142.250.113.101
142.250.113.100
142.250.113.138
```
</p>
</div>
</details> 