### PR TITLE
Add ability to modify value field for RR object

### DIFF
--- a/resolver_test.go
+++ b/resolver_test.go
@@ -158,7 +158,7 @@ func TestGoogleSOA(t *testing.T) {
 	// validate the soa record contains the MNAME and RNAME values split by a space
 	st.Expect(t, count(rrs, func(rr RR) bool {
 		if rr.Type == "SOA" {
-			if len(strings.Split(rr.Value, " ")) == 2 {
+			if len(strings.Fields(rr.Value)) == 2 {
 				return true
 			}
 		}
@@ -172,7 +172,7 @@ func TestGoogleSOA(t *testing.T) {
 	// validate the soa record only contains MNAME value
 	st.Expect(t, count(rrs, func(rr RR) bool {
 		if rr.Type == "SOA" {
-			if len(strings.Split(rr.Value, " ")) == 2 {
+			if len(strings.Fields(rr.Value)) == 2 {
 				return true
 			}
 		}


### PR DESCRIPTION
Currently the RR object does not return the RNAME for a SOA. Only the MNAME (primary nameserver) is returned in the value field as shown below.
```
return RR{toLowerFQDN(t.Hdr.Name), "SOA", toLowerFQDN(t.Ns), ttl, expiry}, true
```

While the use case might be not be typical, it may be useful in some scenarios.

In order to be mindful of not introducing a breaking change, functional options are introduced to act as optional modifiers. These options could be selected, for now the only is to modify the value and include the RNAME. 

A SOA record has additional information such as expiry, minTTL, etc, however it remains to be seen whether those fields are useful and could be included as options.

Alternatively, a breaking change could be introduced to return the RNAME or add a field (modify the RR struct)