### PR TITLE
update dnsr package to go 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/domainr/dnsr
 
-go 1.21
+go 1.23
 
 require (
 	github.com/miekg/dns v1.1.63


### PR DESCRIPTION
Update to go 1.23 as many dependencies now require go 1.23 minimally